### PR TITLE
[#9] ExpenseTable 컴포넌트 구현 및 테스

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import {BrowserRouter, Routes, Route} from 'react-router-dom';
 import {CreateGroup} from './components/CreateGroup';
 import {AddMembers} from './components/AddMembers';
-import ExpenseMain from './components/ExpenseMain';
+import {ExpenseMain} from './components/ExpenseMain';
 import {RecoilRoot} from 'recoil';
 import 'bootstrap/dist/css/bootstrap.min.css';
 

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,38 +1,4 @@
-.App {
-  text-align: center;
-}
-
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+#root {
+  height: 100vh;
+  background: #E5E3E5;
 }

--- a/src/components/AddExpenseForm.jsx
+++ b/src/components/AddExpenseForm.jsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import {Button, Col, Form, Row} from 'react-bootstrap';
+import {Button, Form, Row} from 'react-bootstrap';
 import {useRecoilValue, useSetRecoilState} from 'recoil';
 import {groupMembersState} from '../state/groupMembers';
 import {expensesState} from '../state/expenses';
@@ -89,53 +89,51 @@ export const AddExpenseForm = () => {
                     </Form.Group>
                 </StyledRow>
                 <StyledRow>
-                    <Col xs={12} lg={6}>
-                        <Form.Group>
-                            <Form.Control
-                                type="number"
-                                name="expenseAmount"
-                                step="0.01"
-                                value={amount || ''}
-                                onChange={(e) => setAmount(e.target.value || 0)}
-                                isValid={isAmountValid}
-                                isInvalid={!isAmountValid && isFormValidated}
-                                placeholder="비용은 얼마였나요?"/>
-                            <Form.Control.Feedback
-                                type="invalid"
-                                data-valid={isAmountValid}
-                            >금액을 입력해주셔야 합니다.</Form.Control.Feedback>
-                        </Form.Group>
-                    </Col>
-                    <Col xs={12} lg={6}>
-                        <Form.Group>
-                            <Form.Select
-                                className="form-control"
-                                name="expensePayer"
-                                defaultValue=""
-                                onChange={(e) => setPayer(e.target.value)}
-                                isValid={isPayerValid}
-                                isInvalid={!isPayerValid && isFormValidated}
-                                placeholder="누가 결제했나요?">
-                                <option disabled value="">누가 결제했나요?</option>
-                                {members.map(member => {
-                                    return <option key={member} value={member}>{member}</option>
-                                })}
-                                <option value="영수">영수</option>
-                                <option value="영희">영희</option>
-                            </Form.Select>
-                            <Form.Control.Feedback
-                                type="invalid"
-                                data-valid={isPayerValid}
-                            >결제자를 선택해주셔야 합니다.</Form.Control.Feedback>
-                        </Form.Group>
-                    </Col>
+                    <Form.Group>
+                        <Form.Control
+                            type="number"
+                            name="expenseAmount"
+                            step="0.01"
+                            value={amount || ''}
+                            onChange={(e) => setAmount(e.target.value || 0)}
+                            isValid={isAmountValid}
+                            isInvalid={!isAmountValid && isFormValidated}
+                            placeholder="비용은 얼마였나요?"/>
+                        <Form.Control.Feedback
+                            type="invalid"
+                            data-valid={isAmountValid}
+                        >금액을 입력해주셔야 합니다.</Form.Control.Feedback>
+                    </Form.Group>
                 </StyledRow>
                 <StyledRow>
-                    <StyledSubmitButton type="submit">추가하기</StyledSubmitButton>
-                </StyledRow>
-            </StyledForm>
-        </StyledWrapper>
-    );
+                    <Form.Group>
+                        <Form.Select
+                            className="form-control"
+                            name="expensePayer"
+                            defaultValue=""
+                            onChange={(e) => setPayer(e.target.value)}
+                            isValid={isPayerValid}
+                            isInvalid={!isPayerValid && isFormValidated}
+                            placeholder="누가 결제했나요?">
+                            <option disabled value="">누가 결제했나요?</option>
+                            {members.map(member => {
+                                return <option key={member} value={member}>{member}</option>
+                            })}
+                            <option value="영수">영수</option>
+                            <option value="영희">영희</option>
+                        </Form.Select>
+                        <Form.Control.Feedback
+                            type="invalid"
+                            data-valid={isPayerValid}
+                        >결제자를 선택해주셔야 합니다.</Form.Control.Feedback>
+                    </Form.Group>
+            </StyledRow>
+            <StyledRow>
+                <StyledSubmitButton type="submit">추가하기</StyledSubmitButton>
+            </StyledRow>
+        </StyledForm>
+</StyledWrapper>
+);
 };
 
 const StyledWrapper = styled.div`
@@ -150,11 +148,13 @@ const StyledForm = styled(Form)`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  
+
   width: 100%;
   gap: 15px;
 
   input, select {
+    font-size: 14px;
+
     background: #59359A;
     box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.25);
     border-radius: 8px;
@@ -178,10 +178,11 @@ const StyledTitle = styled.h3`
   color: #FFFBFB;
   text-align: center;
   font-weight: 700;
-  font-size: 35px;
+  font-size: 32px;
   line-height: 48px;
   letter-spacing: 0.25px;
   margin-bottom: 15px;
+  
   @media screen and (max-width: 600px) {
     font-size: 8vw;
   }

--- a/src/components/AddExpenseForm.jsx
+++ b/src/components/AddExpenseForm.jsx
@@ -61,7 +61,7 @@ export const AddExpenseForm = () => {
             <StyledForm
                 noValidate
                 onSubmit={handleSubmit}>
-                <h3>1. 비용 추가하기</h3>
+                <StyledTitle>1. 비용 추가하기</StyledTitle>
                 <StyledRow>
                     <Form.Group>
                         <Form.Control
@@ -94,8 +94,9 @@ export const AddExpenseForm = () => {
                             <Form.Control
                                 type="number"
                                 name="expenseAmount"
-                                value={amount}
-                                onChange={(e) => setAmount(e.target.value)}
+                                step="0.01"
+                                value={amount || ''}
+                                onChange={(e) => setAmount(e.target.value || 0)}
                                 isValid={isAmountValid}
                                 isInvalid={!isAmountValid && isFormValidated}
                                 placeholder="비용은 얼마였나요?"/>
@@ -108,6 +109,7 @@ export const AddExpenseForm = () => {
                     <Col xs={12} lg={6}>
                         <Form.Group>
                             <Form.Select
+                                className="form-control"
                                 name="expensePayer"
                                 defaultValue=""
                                 onChange={(e) => setPayer(e.target.value)}
@@ -116,7 +118,7 @@ export const AddExpenseForm = () => {
                                 placeholder="누가 결제했나요?">
                                 <option disabled value="">누가 결제했나요?</option>
                                 {members.map(member => {
-                                    <option key={member} value={member}>{member}</option>
+                                    return <option key={member} value={member}>{member}</option>
                                 })}
                                 <option value="영수">영수</option>
                                 <option value="영희">영희</option>
@@ -147,7 +149,7 @@ const StyledForm = styled(Form)`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-items: flex-start;
+  align-items: center;
   
   width: 100%;
   gap: 15px;
@@ -169,6 +171,19 @@ const StyledForm = styled(Form)`
     ::placeholder {
       color: #F8F9FA;
     }
+  }
+`
+
+const StyledTitle = styled.h3`
+  color: #FFFBFB;
+  text-align: center;
+  font-weight: 700;
+  font-size: 35px;
+  line-height: 48px;
+  letter-spacing: 0.25px;
+  margin-bottom: 15px;
+  @media screen and (max-width: 600px) {
+    font-size: 8vw;
   }
 `
 

--- a/src/components/ExpenseMain.jsx
+++ b/src/components/ExpenseMain.jsx
@@ -1,22 +1,78 @@
 import React from 'react';
 import {AddExpenseForm} from './AddExpenseForm';
 import {ExpenseTable} from './ExpenseTable';
+import {Col, Container, Row} from 'react-bootstrap';
+import styled from 'styled-components';
 
-const ExpenseMain = () => {
+export const ExpenseMain = () => {
+    // const groupName = useRecoilValue(groupNameState)
+    const groupName = "TESTST"
+
     return (
-        <div>
-            {/* Left Pane */}
-            <div>
+        <StyledExpensesMainWrapper>
+            <LeftPane xs={12} sm={6} md={5}>
+                <StyledTitle>Split Bill</StyledTitle>
                 <AddExpenseForm />
-            {/* TODO: 정산 결과 폼 렌더링 */}
-            </div>
-            {/* Right Pane */}
-            <div>
-            {/* TODO: 그룹명 헤더 렌더링 */}
+                {/* TODO: 정산 결과 폼 렌더링 */}
+            </LeftPane>
+            <RightPane>
+                <StyledGroupName>{groupName}</StyledGroupName>
                 <ExpenseTable />
-            </div>
-        </div>
-    );
+            </RightPane>
+        </StyledExpensesMainWrapper>
+);
 };
 
-export default ExpenseMain;
+const StyledExpensesMainWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  margin: 0;
+
+  background: #E5E3E6;
+  
+  @media screen and (max-width: 768px) {
+    flex-direction: column;
+  }
+`
+
+const LeftPane = styled(Col)`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 100px 60px;
+  gap: 75px;
+  
+  align-content: stretch;
+`
+
+const RightPane = styled(Col)`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 100px 30px;
+  gap: 75px;
+`
+
+const StyledTitle = styled.h1`
+  font-weight: 700;
+  font-size: 48px;
+  line-height: 1;
+
+  letter-spacing: 0.25px;
+
+  color: #8C68CD;
+  text-shadow: 2px 3px 2px rgba(0, 0, 0, 0.3);
+`
+
+const StyledGroupName = styled.h1`
+  font-size: 48px;
+  line-height: 1;
+
+  letter-spacing: 0.25px;
+  color: #212121;
+`

--- a/src/components/ExpenseMain.jsx
+++ b/src/components/ExpenseMain.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {AddExpenseForm} from './AddExpenseForm';
+import {ExpenseTable} from './ExpenseTable';
 
 const ExpenseMain = () => {
     return (
@@ -12,7 +13,7 @@ const ExpenseMain = () => {
             {/* Right Pane */}
             <div>
             {/* TODO: 그룹명 헤더 렌더링 */}
-            {/* TODO: 비용 리스트 컴포넌트 렌더링 */}
+                <ExpenseTable />
             </div>
         </div>
     );

--- a/src/components/ExpenseMain.spec.jsx
+++ b/src/components/ExpenseMain.spec.jsx
@@ -1,5 +1,5 @@
 import {RecoilRoot} from 'recoil';
-import ExpenseMain from './ExpenseMain';
+import {ExpenseMain} from './ExpenseMain';
 import {render, screen, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/components/ExpenseMain.spec.jsx
+++ b/src/components/ExpenseMain.spec.jsx
@@ -87,8 +87,8 @@ describe('비용 정산 메인 페이지', () => {
             await userEvent.selectOptions(payerInput, '영수')
             await userEvent.click(addButton)
         }
-        test('날짜, 내용, 결제자, 금액 데이터가 정산 리슽트에 추가된다', () => {
-            addNewExpense()
+        test('날짜, 내용, 결제자, 금액 데이터가 정산 리슽트에 추가된다', async () => {
+            await addNewExpense()
             const expenseListComponent = screen.getByTestId('expenseList')
             const dateValue = within(expenseListComponent).getByText('2023-01-01')
             expect(dateValue).toBeInTheDocument()

--- a/src/components/ExpenseMain.spec.jsx
+++ b/src/components/ExpenseMain.spec.jsx
@@ -1,6 +1,6 @@
 import {RecoilRoot} from 'recoil';
 import ExpenseMain from './ExpenseMain';
-import {render, screen} from '@testing-library/react';
+import {render, screen, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 const renderComponent = () => {
@@ -70,4 +70,37 @@ describe('비용 정산 메인 페이지', () => {
         })
     })
 
+    describe('비용 리스트 컴포넌트', () => {
+        test('비용 리스트 컴포넌트가 렌더링 되는가?', () => {
+            renderComponent()
+            const expenseListComponent = screen.getByTestId('expenseList')
+            expect(expenseListComponent).toBeInTheDocument()
+        })
+    })
+
+    describe('새로운 비용이 입력되었을때', () => {
+        const addNewExpense = async () => {
+            const {dateInput, descInput, payerInput, amountInput, addButton} = renderComponent()
+            await userEvent.type(dateInput, '2023-01-01')
+            await userEvent.type(descInput, '장보기')
+            await userEvent.type(amountInput, '30000')
+            await userEvent.selectOptions(payerInput, '영수')
+            await userEvent.click(addButton)
+        }
+        test('날짜, 내용, 결제자, 금액 데이터가 정산 리슽트에 추가된다', () => {
+            addNewExpense()
+            const expenseListComponent = screen.getByTestId('expenseList')
+            const dateValue = within(expenseListComponent).getByText('2023-01-01')
+            expect(dateValue).toBeInTheDocument()
+
+            const descValue = within(expenseListComponent).getByText('장보기')
+            expect(descValue).toBeInTheDocument()
+
+            const payerValue = within(expenseListComponent).getByText('영수')
+            expect(payerValue).toBeInTheDocument()
+
+            const amountValue = within(expenseListComponent).getByText('30000')
+            expect(amountValue).toBeInTheDocument()
+        })
+    })
 })

--- a/src/components/ExpenseTable.jsx
+++ b/src/components/ExpenseTable.jsx
@@ -2,26 +2,29 @@ import React from 'react';
 import {useRecoilValue} from 'recoil';
 import {expensesState} from '../state/expenses';
 import {Table} from 'react-bootstrap';
+import {OverlayWrapper} from './Shared/OverlayWrapper';
+import styled from 'styled-components';
 
 export const ExpenseTable = () => {
     const expenses = useRecoilValue(expensesState)
 
     return (
-        <Table
-            data-testid="expenseList"
-            borderless
-            hover
-            responseive
-        >
-            <thead>
-                <tr>
-                    <th>날짜</th>
-                    <th>내용</th>
-                    <th>결제자</th>
-                    <th>금액</th>
-                </tr>
-            </thead>
-            <tbody>
+        <OverlayWrapper minHeight={"75vh"}>
+            <StyledTable
+                data-testid="expenseList"
+                borderless
+                hover
+                responsive
+            >
+                <StyledTableHeader>
+                    <tr>
+                        <th>날짜</th>
+                        <th>내용</th>
+                        <th>결제자</th>
+                        <th>금액</th>
+                    </tr>
+                </StyledTableHeader>
+                <StyledTableBody>
                 {expenses.map(({date, desc, payer, amount}) => {
                     return (
                         <tr>
@@ -32,8 +35,85 @@ export const ExpenseTable = () => {
                         </tr>
                     )
                 })}
-            </tbody>
-
-        </Table>
+                </StyledTableBody>
+            </StyledTable>
+        </OverlayWrapper>
     );
 };
+
+const StyledTable = styled(Table)`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 0;
+  margin: 0 auto;
+
+  align-content: stretch;
+
+  min-width: 450px;
+  @media screen and (max-width: 600px) {
+    min-width: 300px;
+  }
+`
+
+const StyledTableHeader = styled.thead`
+  color: #6B3DA6;
+  text-align: center;
+  font-weight: 700;
+  font-size: 18px;
+  line-height: 25px;
+
+  width: 100%;
+  background: rgba(250, 251, 255, 0.96);
+  
+  tr {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    
+    width: 100%;
+  }
+
+  th {
+    padding: 15px 8px;
+    width: 100%;
+  }
+
+  @media screen and (max-width: 600px) {
+    font-size: 4vw;
+    line-height: 10px;
+
+    th {
+      padding: 10px 4px;
+    }
+  }
+`
+
+const StyledTableBody = styled.tbody`
+  width: 100%;
+
+  tr {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+
+    width: 100%;
+  }
+  
+  td {
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 50px;
+    text-align: center;
+    
+    width: 100%;
+
+    @media screen and (max-width: 600px) {
+      font-size: 4vw;
+      line-height: 20px;
+    }
+  }
+`

--- a/src/components/ExpenseTable.jsx
+++ b/src/components/ExpenseTable.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import {useRecoilValue} from 'recoil';
+import {expensesState} from '../state/expenses';
+import {Table} from 'react-bootstrap';
+
+export const ExpenseTable = () => {
+    const expenses = useRecoilValue(expensesState)
+
+    return (
+        <Table
+            data-testid="expenseList"
+            borderless
+            hover
+            responseive
+        >
+            <thead>
+                <tr>
+                    <th>날짜</th>
+                    <th>내용</th>
+                    <th>결제자</th>
+                    <th>금액</th>
+                </tr>
+            </thead>
+            <tbody>
+                {expenses.map(({date, desc, payer, amount}) => {
+                    return (
+                        <tr>
+                            <td>{date}</td>
+                            <td>{desc}</td>
+                            <td>{payer}</td>
+                            <td>{amount}</td>
+                        </tr>
+                    )
+                })}
+            </tbody>
+
+        </Table>
+    );
+};

--- a/src/components/Shared/OverlayWrapper.jsx
+++ b/src/components/Shared/OverlayWrapper.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
 
-export const OverlayWrapper = ({children}) => {
+export const OverlayWrapper = ({children, padding, minHeight}) => {
     return (
-        <StyledContainer>
+        <StyledContainer padding={padding} minHeight={minHeight}>
             {children}
         </StyledContainer>
     );
@@ -11,12 +11,17 @@ export const OverlayWrapper = ({children}) => {
 
 const StyledContainer = styled.div`
   padding: ${props => props.padding || '5vw'};
-  
+
   border: 1px dashed #9747FF;
   border-radius: 5px;
 
   background-color: white;
   filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
 
-  min-height: ${props => props.minHeight || '0'}}
+  width: 100%;
+  min-height: ${props => props.minHeight || '0'};
+
+  @media screen and (max-width: 600px) {
+    padding: 6vw;
+  }
 `

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,3 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
 }


### PR DESCRIPTION
### 🗒️Description

더치 페이를 위한 '정산 비용 리스트' 컴포넌트 구현하기. 결제일, 결제자, 결제 내용 및 비용을 보여주는 리스트입니다.

### ✅ 체크리스트

- [x] '정산 비용 리스트' 컴포넌트 UI 테스트
- [x] '정산 비용 리스트' 컴포넌트 구현

### 관련 이슈

- Close [[FE] 정산 비용 리스트 컴포넌트 구현](https://github.com/michaelhur/split-bill/issues/9) #9