### PR TITLE
[#24] 그룹 정보 읽기 API

### DIFF
--- a/amplify/backend/amplify-meta.json
+++ b/amplify/backend/amplify-meta.json
@@ -72,7 +72,7 @@
         "LambdaExecutionRole": "splitbillLambdaRole95d085b7-staging"
       },
       "lastPushDirHash": "CYxO1RiuQWF5FDfgoSeGawSc75k=",
-      "lastDevBuildTimeStamp": "2023-02-15T08:23:22.043Z"
+      "lastDevBuildTimeStamp": "2023-02-15T08:41:31.386Z"
     }
   },
   "api": {

--- a/amplify/backend/function/splitBillsLambda/src/event-readGroup.json
+++ b/amplify/backend/function/splitBillsLambda/src/event-readGroup.json
@@ -1,0 +1,7 @@
+{
+  "httpMethod": "GET",
+  "path": "/groups/19536b30-ac4d-11ed-a60c-6fa2a8cbbcd3",
+  "headers": {
+    "Content-Type": "application/json"
+  }
+}


### PR DESCRIPTION
### 🗒️Description

- AWS Amplify와 AWS Lambda를 이용하여 그룹별로 '정산 상세 내역 읽어오는' API 추가하기

### ✅ 체크리스트

- [x] 그룹 읽기 API 구현

### 관련 이슈

- close #24