### PR TITLE
[#28] 프론트엔드 API 연동

### DIFF
--- a/amplify/#current-cloud-backend/amplify-meta.json
+++ b/amplify/#current-cloud-backend/amplify-meta.json
@@ -20,7 +20,7 @@
         "s3TemplateURL": "https://s3.amazonaws.com/amplify-amplify1228e3bc9d704-staging-152518-deployment/amplify-cfn-templates/storage/groups-cloudformation-template.json",
         "logicalId": "storagegroups"
       },
-      "lastPushTimeStamp": "2023-02-15T16:34:00.945Z",
+      "lastPushTimeStamp": "2023-02-16T07:32:58.712Z",
       "output": {
         "PartitionKeyName": "guid",
         "Region": "ap-northeast-2",
@@ -51,20 +51,20 @@
           }
         }
       ],
-      "lastDevBuildTimeStamp": "2023-02-15T16:29:40.706Z",
+      "lastDevBuildTimeStamp": "2023-02-15T16:39:09.145Z",
       "lastBuildType": "PROD",
-      "lastBuildTimeStamp": "2023-02-15T16:29:54.677Z",
-      "lastPackageTimeStamp": "2023-02-15T16:29:55.002Z",
-      "distZipFilename": "groupsLambda-3035684e78614757744c-build.zip",
+      "lastBuildTimeStamp": "2023-02-16T07:31:51.375Z",
+      "lastPackageTimeStamp": "2023-02-16T07:31:52.039Z",
+      "distZipFilename": "groupsLambda-564b444e545754454243-build.zip",
       "s3Bucket": {
         "deploymentBucketName": "amplify-amplify1228e3bc9d704-staging-152518-deployment",
-        "s3Key": "amplify-builds/groupsLambda-3035684e78614757744c-build.zip"
+        "s3Key": "amplify-builds/groupsLambda-564b444e545754454243-build.zip"
       },
       "providerMetadata": {
         "s3TemplateURL": "https://s3.amazonaws.com/amplify-amplify1228e3bc9d704-staging-152518-deployment/amplify-cfn-templates/function/groupsLambda-cloudformation-template.json",
         "logicalId": "functiongroupsLambda"
       },
-      "lastPushTimeStamp": "2023-02-15T16:34:00.945Z",
+      "lastPushTimeStamp": "2023-02-16T07:32:58.957Z",
       "output": {
         "LambdaExecutionRoleArn": "arn:aws:iam::614309495310:role/splitbillLambdaRoledd25e3ce-staging",
         "Region": "ap-northeast-2",
@@ -72,7 +72,7 @@
         "Name": "groupsLambda-staging",
         "LambdaExecutionRole": "splitbillLambdaRoledd25e3ce-staging"
       },
-      "lastPushDirHash": "+RFxJqUWWVqkm+hvyPr8cDPNdxc="
+      "lastPushDirHash": "W/2yJY7iGoFpD+NahV/m8Ay2hCU="
     }
   },
   "api": {
@@ -93,7 +93,7 @@
         "s3TemplateURL": "https://s3.amazonaws.com/amplify-amplify1228e3bc9d704-staging-152518-deployment/amplify-cfn-templates/api/groupsApi-cloudformation-template.json",
         "logicalId": "apigroupsApi"
       },
-      "lastPushTimeStamp": "2023-02-15T16:34:00.945Z",
+      "lastPushTimeStamp": "2023-02-16T07:32:58.720Z",
       "output": {
         "ApiName": "groupsApi",
         "RootUrl": "https://c0xrdng33l.execute-api.ap-northeast-2.amazonaws.com/staging",

--- a/amplify/backend/amplify-meta.json
+++ b/amplify/backend/amplify-meta.json
@@ -20,7 +20,7 @@
         "s3TemplateURL": "https://s3.amazonaws.com/amplify-amplify1228e3bc9d704-staging-152518-deployment/amplify-cfn-templates/storage/groups-cloudformation-template.json",
         "logicalId": "storagegroups"
       },
-      "lastPushTimeStamp": "2023-02-15T16:34:00.945Z",
+      "lastPushTimeStamp": "2023-02-16T07:32:58.712Z",
       "output": {
         "PartitionKeyName": "guid",
         "Region": "ap-northeast-2",
@@ -52,19 +52,19 @@
         }
       ],
       "lastDevBuildTimeStamp": "2023-02-15T16:39:09.145Z",
-      "lastBuildType": "DEV",
-      "lastBuildTimeStamp": "2023-02-15T16:29:54.677Z",
-      "lastPackageTimeStamp": "2023-02-15T16:29:55.002Z",
-      "distZipFilename": "groupsLambda-3035684e78614757744c-build.zip",
+      "lastBuildType": "PROD",
+      "lastBuildTimeStamp": "2023-02-16T07:31:51.375Z",
+      "lastPackageTimeStamp": "2023-02-16T07:31:52.039Z",
+      "distZipFilename": "groupsLambda-564b444e545754454243-build.zip",
       "s3Bucket": {
         "deploymentBucketName": "amplify-amplify1228e3bc9d704-staging-152518-deployment",
-        "s3Key": "amplify-builds/groupsLambda-3035684e78614757744c-build.zip"
+        "s3Key": "amplify-builds/groupsLambda-564b444e545754454243-build.zip"
       },
       "providerMetadata": {
         "s3TemplateURL": "https://s3.amazonaws.com/amplify-amplify1228e3bc9d704-staging-152518-deployment/amplify-cfn-templates/function/groupsLambda-cloudformation-template.json",
         "logicalId": "functiongroupsLambda"
       },
-      "lastPushTimeStamp": "2023-02-15T16:34:00.945Z",
+      "lastPushTimeStamp": "2023-02-16T07:32:58.957Z",
       "output": {
         "LambdaExecutionRoleArn": "arn:aws:iam::614309495310:role/splitbillLambdaRoledd25e3ce-staging",
         "Region": "ap-northeast-2",
@@ -72,7 +72,7 @@
         "Name": "groupsLambda-staging",
         "LambdaExecutionRole": "splitbillLambdaRoledd25e3ce-staging"
       },
-      "lastPushDirHash": "+RFxJqUWWVqkm+hvyPr8cDPNdxc="
+      "lastPushDirHash": "W/2yJY7iGoFpD+NahV/m8Ay2hCU="
     }
   },
   "api": {
@@ -93,7 +93,7 @@
         "s3TemplateURL": "https://s3.amazonaws.com/amplify-amplify1228e3bc9d704-staging-152518-deployment/amplify-cfn-templates/api/groupsApi-cloudformation-template.json",
         "logicalId": "apigroupsApi"
       },
-      "lastPushTimeStamp": "2023-02-15T16:34:00.945Z",
+      "lastPushTimeStamp": "2023-02-16T07:32:58.720Z",
       "output": {
         "ApiName": "groupsApi",
         "RootUrl": "https://c0xrdng33l.execute-api.ap-northeast-2.amazonaws.com/staging",

--- a/amplify/backend/function/groupsLambda/src/package-lock.json
+++ b/amplify/backend/function/groupsLambda/src/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "aws-serverless-express": "^3.3.5",
         "body-parser": "^1.19.1",
-        "express": "^4.17.2"
+        "express": "^4.17.2",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.92",
@@ -84,6 +85,15 @@
       },
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-sdk/node_modules/uuid": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/aws-serverless-express": {
@@ -860,10 +870,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
-      "dev": true,
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -968,6 +977,14 @@
         "util": "^0.12.4",
         "uuid": "8.0.0",
         "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+          "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
+          "dev": true
+        }
       }
     },
     "aws-serverless-express": {
@@ -1538,10 +1555,9 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
     },
     "uuid": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
-      "dev": true
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/amplify/backend/function/groupsLambda/src/package.json
+++ b/amplify/backend/function/groupsLambda/src/package.json
@@ -7,7 +7,8 @@
   "dependencies": {
     "aws-serverless-express": "^3.3.5",
     "body-parser": "^1.19.1",
-    "express": "^4.17.2"
+    "express": "^4.17.2",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.92",

--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -15,7 +15,7 @@
       "function": {
         "groupsLambda": {
           "deploymentBucketName": "amplify-amplify1228e3bc9d704-staging-152518-deployment",
-          "s3Key": "amplify-builds/groupsLambda-3035684e78614757744c-build.zip"
+          "s3Key": "amplify-builds/groupsLambda-564b444e545754454243-build.zip"
         }
       },
       "storage": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,7 +15,7 @@ const App = () => {
         <BrowserRouter>
             <RecoilRoot>
                 <Routes>
-                    <Route path="/" element={<Navigate to="/group" />} />
+                    <Route path="/" element={<Navigate to={ROUTES.CREATE_GROUP} />} />
                     <Route path={ROUTES.CREATE_GROUP} element={<CreateGroup />} />
                     <Route path={ROUTES.ADD_MEMBERS} element={<AddMembers />} />
                     <Route path={ROUTES.EXPENSE_MAIN} element={<ExpenseMain />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,10 @@ import {ExpenseMain} from './components/ExpenseMain';
 import {RecoilRoot} from 'recoil';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import {ROUTES} from './routes';
+import {Amplify} from 'aws-amplify';
+import awsmobile from './aws-exports';
 
+Amplify.configure(awsmobile)
 
 const App = () => {
     return (

--- a/src/components/AddExpenseForm.jsx
+++ b/src/components/AddExpenseForm.jsx
@@ -4,6 +4,8 @@ import {useRecoilValue, useSetRecoilState} from 'recoil';
 import {groupMembersState} from '../state/groupMembers';
 import {expensesState} from '../state/expenses';
 import styled from 'styled-components';
+import {API} from 'aws-amplify';
+import {groupIdState} from '../state/groupId';
 
 export const AddExpenseForm = () => {
     const members = useRecoilValue(groupMembersState)
@@ -21,6 +23,7 @@ export const AddExpenseForm = () => {
     const [isAmountValid, setIsAmountValid] = useState(false);
     const [isPayerValid, setIsPayerValid] = useState(false);
 
+    const guid = useRecoilValue(groupIdState)
     const addExpense = useSetRecoilState(expensesState)
 
     const checkFormValidity = () => {
@@ -35,6 +38,21 @@ export const AddExpenseForm = () => {
         return descValid && payerValid && amountValid
     }
 
+    const saveExpense = (newExpense) => {
+        API.put('groupsApi', `/groups/${guid}/expenses`, {
+            body: {
+                expense: newExpense
+            }
+        })
+            .then(response => {
+                addExpense(prevExpenses => [
+                    ...prevExpenses,
+                    newExpense
+                ])
+            })
+            .catch()
+    }
+
     const handleSubmit = (event) => {
         event.preventDefault()
 
@@ -45,10 +63,7 @@ export const AddExpenseForm = () => {
                 amount,
                 payer
             }
-            addExpense(prevExpenses => [
-                ...prevExpenses,
-                newExpense
-            ])
+            saveExpense(newExpense)
         }
 
         setIsFormValidated(true)

--- a/src/components/AddMembers.jsx
+++ b/src/components/AddMembers.jsx
@@ -8,6 +8,7 @@ import styled from 'styled-components';
 import {useNavigate} from 'react-router-dom';
 import {ROUTES} from '../routes';
 import {groupIdState} from '../state/groupId';
+import {API} from 'aws-amplify';
 
 export const AddMembers = () => {
     const navigate = useNavigate()
@@ -18,15 +19,31 @@ export const AddMembers = () => {
     const groupName = useRecoilValue(groupNameState)
     const [groupMembers, setGroupMembers] = useRecoilState(groupMembersState)
 
+    const title = `${groupName} 그룹의 속한 사람들의 이름을 모두 적어주세요!`
+    const isError = formSubmitted && groupMembers.length === 0
+
+    const saveGroupMembers = () => {
+        API.put('groupsApi', `/groups/${groupId}/members`, {
+            body: {
+                members: groupMembers
+            }
+        })
+            .then((response) => {
+                navigate(ROUTES.EXPENSE_MAIN)
+            })
+            .catch(error => {
+                console.log(error.response)
+            })
+    }
+
     const handleSubmit = (event) => {
         event.preventDefault()
         setFormSubmitted(true)
         setValidated(true)
-        navigate(ROUTES.EXPENSE_MAIN)
+        if (groupMembers.length > 0) {
+            saveGroupMembers()
+        }
     }
-
-    const title = `${groupName} 그룹의 속한 사람들의 이름을 모두 적어주세요!`
-    const isError = formSubmitted && groupMembers.length === 0
 
     return (
         <CenteredOverlayForm

--- a/src/components/AddMembers.jsx
+++ b/src/components/AddMembers.jsx
@@ -7,12 +7,14 @@ import {groupMembersState} from '../state/groupMembers';
 import styled from 'styled-components';
 import {useNavigate} from 'react-router-dom';
 import {ROUTES} from '../routes';
+import {groupIdState} from '../state/groupId';
 
 export const AddMembers = () => {
     const navigate = useNavigate()
     const [formSubmitted, setFormSubmitted] = useState(false);
     const [validated, setValidated] = useState(false);
 
+    const groupId = useRecoilValue(groupIdState)
     const groupName = useRecoilValue(groupNameState)
     const [groupMembers, setGroupMembers] = useRecoilState(groupMembersState)
 

--- a/src/components/AddMembers.jsx
+++ b/src/components/AddMembers.jsx
@@ -6,7 +6,7 @@ import {groupNameState} from '../state/groupName';
 import {groupMembersState} from '../state/groupMembers';
 import styled from 'styled-components';
 import {useNavigate} from 'react-router-dom';
-import {ROUTES} from '../routes';
+import {ROUTE_UTILS, ROUTES} from '../routes';
 import {groupIdState} from '../state/groupId';
 import {API} from 'aws-amplify';
 
@@ -15,7 +15,7 @@ export const AddMembers = () => {
     const [formSubmitted, setFormSubmitted] = useState(false);
     const [validated, setValidated] = useState(false);
 
-    const groupId = useRecoilValue(groupIdState)
+    const guid = useRecoilValue(groupIdState)
     const groupName = useRecoilValue(groupNameState)
     const [groupMembers, setGroupMembers] = useRecoilState(groupMembersState)
 
@@ -23,13 +23,13 @@ export const AddMembers = () => {
     const isError = formSubmitted && groupMembers.length === 0
 
     const saveGroupMembers = () => {
-        API.put('groupsApi', `/groups/${groupId}/members`, {
+        API.put('groupsApi', `/groups/${guid}/members`, {
             body: {
                 members: groupMembers
             }
         })
             .then((response) => {
-                navigate(ROUTES.EXPENSE_MAIN)
+                navigate(ROUTE_UTILS.EXPENSE_MAIN(guid))
             })
             .catch(error => {
                 console.log(error.response)

--- a/src/components/AddMembers.jsx
+++ b/src/components/AddMembers.jsx
@@ -1,35 +1,33 @@
 import React, {useState} from 'react';
 import {InputTags} from 'react-bootstrap-tagsinput';
 import {CenteredOverlayForm} from './Shared/CenteredOverlayForm';
-import {useRecoilState, useRecoilValue} from 'recoil';
-import {groupNameState} from '../state/groupName';
+import {useSetRecoilState,} from 'recoil';
 import {groupMembersState} from '../state/groupMembers';
 import styled from 'styled-components';
 import {useNavigate} from 'react-router-dom';
-import {ROUTE_UTILS, ROUTES} from '../routes';
-import {groupIdState} from '../state/groupId';
+import {ROUTE_UTILS} from '../routes';
 import {API} from 'aws-amplify';
+import {useGroupData} from '../hooks/useGroupData';
 
 export const AddMembers = () => {
+    const { groupName, groupId, groupMembers} = useGroupData()
+
     const navigate = useNavigate()
     const [formSubmitted, setFormSubmitted] = useState(false);
     const [validated, setValidated] = useState(false);
-
-    const guid = useRecoilValue(groupIdState)
-    const groupName = useRecoilValue(groupNameState)
-    const [groupMembers, setGroupMembers] = useRecoilState(groupMembersState)
+    const setGroupMembers = useSetRecoilState(groupMembersState)
 
     const title = `${groupName} 그룹의 속한 사람들의 이름을 모두 적어주세요!`
     const isError = formSubmitted && groupMembers.length === 0
 
     const saveGroupMembers = () => {
-        API.put('groupsApi', `/groups/${guid}/members`, {
+        API.put('groupsApi', `/groups/${groupId}/members`, {
             body: {
                 members: groupMembers
             }
         })
             .then((response) => {
-                navigate(ROUTE_UTILS.EXPENSE_MAIN(guid))
+                navigate(ROUTE_UTILS.EXPENSE_MAIN(groupId))
             })
             .catch(error => {
                 console.log(error.response)
@@ -53,6 +51,7 @@ export const AddMembers = () => {
             <InputTags
                 id="input-member-names"
                 placeholder="이름 간 띄어쓰기"
+                values={groupMembers}
                 onTags={(value) => {
                     setFormSubmitted(false)
                     setGroupMembers(value.values)

--- a/src/components/CreateGroup.jsx
+++ b/src/components/CreateGroup.jsx
@@ -4,7 +4,7 @@ import {useRecoilState, useSetRecoilState} from 'recoil';
 import {groupNameState} from '../state/groupName';
 import React, {useState} from 'react';
 import {useNavigate} from 'react-router-dom';
-import {ROUTES} from '../routes';
+import {ROUTE_UTILS} from '../routes';
 import {API} from 'aws-amplify';
 import {groupIdState} from '../state/groupId';
 
@@ -23,7 +23,7 @@ export const CreateGroup = () => {
             .then(({data}) => {
                 const {guid} = data;
                 setGroupId(guid)
-                navigate(ROUTES.ADD_MEMBERS)
+                navigate(ROUTE_UTILS.ADD_MEMBERS(guid))
             })
             .catch(error => {
                 console.log("error", error.response)

--- a/src/components/CreateGroup.jsx
+++ b/src/components/CreateGroup.jsx
@@ -1,15 +1,34 @@
 import {CenteredOverlayForm} from './Shared/CenteredOverlayForm';
 import {Form} from 'react-bootstrap';
-import {useSetRecoilState} from 'recoil';
+import {useRecoilState, useSetRecoilState} from 'recoil';
 import {groupNameState} from '../state/groupName';
 import React, {useState} from 'react';
 import {useNavigate} from 'react-router-dom';
 import {ROUTES} from '../routes';
+import {API} from 'aws-amplify';
+import {groupIdState} from '../state/groupId';
 
 export const CreateGroup = () => {
     const navigate = useNavigate()
     const [validated, setValidated] = useState(false);
-    const setGroupName = useSetRecoilState(groupNameState)
+    const [groupName, setGroupName] = useRecoilState(groupNameState)
+    const setGroupId = useSetRecoilState(groupIdState)
+
+    const saveGroupName = () => {
+        API.post('groupsApi', '/groups', {
+            body: {
+                groupName: groupName,
+            }
+        })
+            .then(({data}) => {
+                const {guid} = data;
+                setGroupId(guid)
+                navigate(ROUTES.ADD_MEMBERS)
+            })
+            .catch(error => {
+                console.log("error", error.response)
+            })
+    }
 
     const handleSubmit = (event) => {
         event.preventDefault()
@@ -17,7 +36,7 @@ export const CreateGroup = () => {
         const form = event.currentTarget
         if (form.checkValidity()) {
             event.stopPropagation()
-            navigate(ROUTES.ADD_MEMBERS)
+            saveGroupName()
         }
 
         setValidated(true)

--- a/src/components/ExpenseMain.jsx
+++ b/src/components/ExpenseMain.jsx
@@ -3,13 +3,12 @@ import {AddExpenseForm} from './AddExpenseForm';
 import {ExpenseTable} from './ExpenseTable';
 import {Col} from 'react-bootstrap';
 import styled from 'styled-components';
-import {useRecoilValue} from 'recoil';
-import {groupNameState} from '../state/groupName';
 import {SettlementSummary} from './SettlementSummary';
 import {ServiceLogo} from './Shared/ServiceLogo';
+import {useGroupData} from '../hooks/useGroupData';
 
 export const ExpenseMain = () => {
-    const groupName = useRecoilValue(groupNameState)
+    const {groupName} = useGroupData()
 
     return (
         <StyledExpensesMainWrapper>

--- a/src/components/Shared/CenteredOverlayForm.jsx
+++ b/src/components/Shared/CenteredOverlayForm.jsx
@@ -36,17 +36,6 @@ export const CenteredOverlayForm = ({title, validated, handleSubmit, children}) 
     )
 };
 
-const StyledH1 = styled.h1`
-  font-style: normal;
-  font-weight: 700;
-  font-size: 48px;
-  line-height: 48px;
-
-  letter-spacing: 0.25px;
-
-  color: #6610F2;
-`
-
 const CentralizedContainer = styled(Container)`
   display: flex;
   flex-direction: column;

--- a/src/hooks/useGroupData.jsx
+++ b/src/hooks/useGroupData.jsx
@@ -1,0 +1,45 @@
+import {useEffect} from 'react';
+import {useParams} from 'react-router-dom';
+import {API} from 'aws-amplify';
+import {useRecoilState} from 'recoil';
+import {groupNameState} from '../state/groupName';
+import {groupIdState} from '../state/groupId';
+import {groupMembersState} from '../state/groupMembers';
+import {expensesState} from '../state/expenses';
+
+export const useGroupData = () => {
+    const {guid} = useParams()
+    const apiUrl = `/groups/${guid}`
+    const [groupName, setGroupName] = useRecoilState(groupNameState)
+    const [groupId, setGroupId] = useRecoilState(groupIdState)
+    const [groupMembers, setGroupMembers] = useRecoilState(groupMembersState)
+    const [expenses, setExpenses ]= useRecoilState(expensesState)
+
+    const fetchAndSetGroupData = () => {
+        API.get('groupsApi', apiUrl, {})
+            .then(({data}) =>{
+                setGroupName(data.groupName)
+                setGroupId(data.guid)
+                setGroupMembers(data.members)
+                setExpenses(data.expenses || [])
+            })
+            .catch((error) => {
+                console.log(error.response)
+            })
+    }
+
+    useEffect(() => {
+        if (guid?.length > 0) {
+            fetchAndSetGroupData()
+        }
+    }, [apiUrl, guid])
+
+    return {
+        groupName,
+        groupId,
+        groupMembers,
+        expenses,
+    }
+
+};
+

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,5 +1,12 @@
 export const ROUTES = {
-    CREATE_GROUP: "/group",
-    ADD_MEMBERS: "/members",
-    EXPENSE_MAIN: "/expenses"
+    CREATE_GROUP: "/groups",
+    ADD_MEMBERS: "/groups/:guid/members",
+    EXPENSE_MAIN: "/groups/:guid/expenses"
+}
+
+const replaceGuid = (route, guid) => route.replace(":guid", guid)
+
+export const ROUTE_UTILS = {
+    ADD_MEMBERS: (guid) => replaceGuid(ROUTES.ADD_MEMBERS, guid),
+    EXPENSE_MAIN: (guid) => replaceGuid(ROUTES.EXPENSE_MAIN, guid),
 }

--- a/src/state/groupId.js
+++ b/src/state/groupId.js
@@ -1,0 +1,6 @@
+import {atom} from 'recoil';
+
+export const groupIdState = atom({
+    key: "groupId",
+    default: undefined,
+})


### PR DESCRIPTION
### 🗒️Description

- AWS Amplify로 구현된 백엔드 API서버를 프론트엔드에 연동하기

### ✅ 체크리스트

- [x] 그룹 생성
- [x] 멤버 추가
- [x] 정산 내역 업데이트
- [x] 그룹 읽기


### 관련이슈

- close #28